### PR TITLE
Fix overflow

### DIFF
--- a/src/lib/atoms/sections/SectionTwoHome.svelte
+++ b/src/lib/atoms/sections/SectionTwoHome.svelte
@@ -71,10 +71,8 @@
     }
 
     img {
-        width: 19rem;
-        margin-top: 1rem;
-        margin-bottom: 2rem;
-        margin-left: 2rem;
+        width: 100%;
+        padding: var(--padding);
         border-radius: 40px;
     }
 


### PR DESCRIPTION
Probleem zat in de image op de homepagina, deze heb ik een width gegeven in procenten, daarbij heb ik een padding toegevoegd zodat de afbeelding iets naar binnen komt. Hier de voor en na screenshots:

<img width="309" alt="image" src="https://github.com/TimOosterveer/plantswap-webapplicatie/assets/62908209/9e23b82b-af3e-4b90-88e6-1dc00f334a71">

<img width="313" alt="image" src="https://github.com/TimOosterveer/plantswap-webapplicatie/assets/62908209/e1ed6038-fe20-4e11-ad6a-1746b750ab1d">